### PR TITLE
Support remote workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
     "Other"
   ],
   "activationEvents": [],
-  "contributes": {
+	"extensionKind": [
+		"workspace"
+	],
+	"contributes": {
     "markdown.markdownItPlugins": true,
     "markdown.previewStyles": [
       "checkboxes.css"


### PR DESCRIPTION
This extension works with the Print extension when printing rendered Markdown from local workspaces. Setting extensionKind will allow it to also work with remote workspaces.